### PR TITLE
Fixes the build error occurring due to missing SquarePointOfSaleSDK.h file during pod install. 

### DIFF
--- a/ios/RNSquarePos.m
+++ b/ios/RNSquarePos.m
@@ -1,6 +1,9 @@
 
 #import "RNSquarePos.h"
-#import <SquarePointOfSaleSDK/SquarePointOfSaleSDK.h>
+//Following have been added as the umbrella header file of SquarePointOfSaleSDK.h is no more shipped from upstream SquarePointOfSaleSDK
+#import <SquarePointOfSaleSDK/SCCMoney.h>
+#import <SquarePointOfSaleSDK/SCCAPIRequest.h>
+#import <SquarePointOfSaleSDK/SCCAPIConnection.h>
 #import <Foundation/Foundation.h>
 
 @implementation RNSquarePos
@@ -21,7 +24,7 @@ RCT_EXPORT_METHOD(
 	NSError *error;
 	NSURL *const callbackURL = [NSURL URLWithString:callbackUrl];
 	SCCMoney *const amount = [SCCMoney moneyWithAmountCents:_amount currencyCode:currency error:NULL];
-	[SCCAPIRequest setClientID:applicationId];
+	[SCCAPIRequest setApplicationID:applicationId]; //clientID property is deprecated. Instead per documentation applicationID property needs to be set.
 
 	// notes
 	NSString *notes = nil;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 
 {
   "name": "react-native-square-pos",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "React Native wrapper around Square's Android / iOS POS SDKs",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Fixes #8 

### Context

From the [SquarePointOfSaleSDK](https://github.com/square/SquarePointOfSaleSDK-iOS) file ` SquarePointOfSaleSDK.h` is no more shipped.
As a result post `pod install` when a build is fired it fails with  `<SquarePointOfSaleSDK\SquarePointOfSaleSDK.h> not found`.

### Solution
import the relevant header files directly
